### PR TITLE
Issue #9 - Use 19.08 runtime and Issue #12 - new upstream

### DIFF
--- a/ar.com.tuxguitar.TuxGuitar.appdata.xml
+++ b/ar.com.tuxguitar.TuxGuitar.appdata.xml
@@ -32,6 +32,7 @@
   <url type="bugtracker">https://github.com/flathub/ar.com.tuxguitar.TuxGuitar/issues</url>
   <launchable type="desktop-id">ar.com.tuxguitar.TuxGuitar.desktop</launchable>
   <releases>
+    <release version="1.5.3" date="2019-12-10" />
     <release version="1.5.2" date="2019-02-28" />
     <release version="1.5.1" date="2018-08-03" />
     <release version="1.5" date="2018-02-02">

--- a/ar.com.tuxguitar.TuxGuitar.yml
+++ b/ar.com.tuxguitar.TuxGuitar.yml
@@ -1,6 +1,6 @@
 app-id: ar.com.tuxguitar.TuxGuitar
 runtime: org.freedesktop.Platform
-runtime-version: '18.08'
+runtime-version: '19.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.openjdk11

--- a/ar.com.tuxguitar.TuxGuitar.yml
+++ b/ar.com.tuxguitar.TuxGuitar.yml
@@ -30,7 +30,7 @@ modules:
     buildsystem: simple
     build-commands:
       - mkdir -p /app/bin
-      - tar -xf tuxguitar*.tar.gz --strip 1 --exclude=tuxguitar.sh -C /app/
+      - tar -xf tuxguitar-1.5.3-linux-x86*.tar.gz --strip 1 --exclude=tuxguitar.sh -C /app/
       - install -Dm644 /app/share/skins/Oxygen/icon-64x64.png /app/share/icons/hicolor/64x64/apps/ar.com.tuxguitar.TuxGuitar.png
       - install -Dm644 /app/share/skins/Oxygen/icon-96x96.png /app/share/icons/hicolor/96x96/apps/ar.com.tuxguitar.TuxGuitar.png
       - install -Dm644 ar.com.tuxguitar.TuxGuitar.desktop -t /app/share/applications
@@ -40,15 +40,13 @@ modules:
       - type: file
         only-arches:
           - x86_64
-        url: https://sourceforge.net/projects/tuxguitar/files/TuxGuitar/TuxGuitar-1.5.2/tuxguitar-1.5.2-linux-x86_64.tar.gz/download
-        sha256: 298555a249adb3ad72f3aef72a124e30bfa01cd069c7b5d152a738140e7903a2
-        dest-filename: tuxguitar-x84_64.tar.gz
+        url: https://downloads.sourceforge.net/project/tuxguitar/TuxGuitar/TuxGuitar-1.5.3/tuxguitar-1.5.3-linux-x86_64.tar.gz
+        sha256: f2c83f1544e55ca456219087dde5a52ca8d1daee147d44510b2c78aeaea1748f
       - type: file
         only-arches:
           - i386
-        url: https://sourceforge.net/projects/tuxguitar/files/TuxGuitar/TuxGuitar-1.5.2/tuxguitar-1.5.2-linux-x86.tar.gz/download
-        sha256: 27675c358db237df74d20e8676000c25a87b9de0bb0a6d1c325e8d6db807d296
-        dest-filename: tuxguitar-x84.tar.gz
+        url: https://downloads.sourceforge.net/project/tuxguitar/TuxGuitar/TuxGuitar-1.5.3/tuxguitar-1.5.3-linux-x86.tar.gz
+        sha256: 055777325e35b8c40b3a8594581cc143ab744e69575de6746fb5ad25ba14bafb
       - type: file
         path: tuxguitar.sh
       - type: file

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
-	"only-arches": ["x86_64", "i386"]
+	"only-arches": ["x86_64", "i386"],
+	"skip-icons-check": true
 }

--- a/tuxguitar.sh
+++ b/tuxguitar.sh
@@ -27,4 +27,4 @@ VM_ARGS="-Xmx512m"
 export CLASSPATH
 export LD_LIBRARY_PATH
 
-${JAVA} ${VM_ARGS} -cp :${CLASSPATH} -Dtuxguitar.share.path="/app/share/" -Djava.library.path="${LD_LIBRARY_PATH}" ${MAINCLASS} "$1" "$2"
+${JAVA} ${VM_ARGS} -cp :${CLASSPATH} -Dtuxguitar.home.path="/app" -Dtuxguitar.share.path="/app/share/" -Djava.library.path="${LD_LIBRARY_PATH}" ${MAINCLASS} "$1" "$2"


### PR DESCRIPTION
- Update to freedesktop runtime 19.08
- Update to 1.5.3 from upstream
- Fix wrapper script for the path to the soundfont to be correct (home is `/app`)